### PR TITLE
Add ByPostCreateAt Bookmarks filter method and use as default

### DIFF
--- a/server/command_test.go
+++ b/server/command_test.go
@@ -24,6 +24,11 @@ const (
 	b3ID = "ID3"
 	b4ID = "ID4"
 
+	p1ID = "ID1"
+	p2ID = "ID2"
+	p3ID = "ID3"
+	p4ID = "ID4"
+
 	b1Title = "Title1 - New Bookmark - times are zero"
 	b2Title = "Title2 - bookmarks initialized. Times created and same"
 	b3Title = "Title3 - bookmarks already updated once"
@@ -73,6 +78,24 @@ func getExecuteCommandTestBookmarks() *Bookmarks {
 }
 
 func TestExecuteCommand(t *testing.T) {
+
+	p1IDmodel := &model.Post{
+		Message:  "this is the post.Message",
+		CreateAt: model.GetMillis(),
+	}
+	p2IDmodel := &model.Post{
+		Message:  "this is the post.Message",
+		CreateAt: model.GetMillis() + 1,
+	}
+	p3IDmodel := &model.Post{
+		Message:  "this is the post.Message",
+		CreateAt: model.GetMillis() + 2,
+	}
+	p4IDmodel := &model.Post{
+		Message:  "this is the post.Message",
+		CreateAt: model.GetMillis() + 3,
+	}
+
 	tests := map[string]struct {
 		commandArgs       *model.CommandArgs
 		bookmarks         *Bookmarks
@@ -108,10 +131,10 @@ func TestExecuteCommand(t *testing.T) {
 		tt.commandArgs.UserId = UserID
 		siteURL := "https://myhost.com"
 		api.On("GetPost", PostIDDoesNotExist).Return(nil, &model.AppError{Message: "An Error Occurred"})
-		api.On("GetPost", b1ID).Return(&model.Post{Message: "this is the post.Message"}, nil)
-		api.On("GetPost", b2ID).Return(&model.Post{Message: "this is the post.Message"}, nil)
-		api.On("GetPost", b3ID).Return(&model.Post{Message: "this is the post.Message"}, nil)
-		api.On("GetPost", b4ID).Return(&model.Post{Message: "this is the post.message"}, nil)
+		api.On("GetPost", b1ID).Return(p1IDmodel, nil)
+		api.On("GetPost", b2ID).Return(p2IDmodel, nil)
+		api.On("GetPost", b3ID).Return(p3IDmodel, nil)
+		api.On("GetPost", b4ID).Return(p4IDmodel, nil)
 		api.On("addBookmark", UserID, tt.bookmarks).Return(mock.Anything)
 		api.On("GetTeam", mock.Anything).Return(&model.Team{Id: teamID1}, nil)
 		api.On("GetConfig", mock.Anything).Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: &siteURL}})

--- a/server/command_view.go
+++ b/server/command_view.go
@@ -45,7 +45,12 @@ func (p *Plugin) executeCommandView(args *model.CommandArgs) *model.CommandRespo
 	}
 
 	text := "#### Bookmarks List\n"
-	for _, bmark := range bookmarks.ByID {
+	bmarksSorted, appErr := p.ByPostCreateAt(bookmarks)
+	if appErr != nil {
+		return p.responsef(args, "Unable to retrieve bookmarks for user %s", args.UserId)
+	}
+
+	for _, bmark := range bmarksSorted {
 		nextText, appErr := p.getBmarkTextOneLine(bmark, args)
 		if appErr != nil {
 			return p.responsef(args, "Unable to get bookmarks list bookmark")

--- a/server/command_view_test.go
+++ b/server/command_view_test.go
@@ -13,6 +13,24 @@ import (
 )
 
 func TestExecuteCommandView(t *testing.T) {
+
+	p1IDmodel := &model.Post{
+		Message:  "this is the post.Message",
+		CreateAt: model.GetMillis(),
+	}
+	p2IDmodel := &model.Post{
+		Message:  "this is the post.Message",
+		CreateAt: model.GetMillis() + 5,
+	}
+	p3IDmodel := &model.Post{
+		Message:  "this is the post.Message",
+		CreateAt: model.GetMillis() + 2,
+	}
+	p4IDmodel := &model.Post{
+		Message:  "this is the post.Message",
+		CreateAt: model.GetMillis() + 3,
+	}
+
 	tests := map[string]struct {
 		commandArgs       *model.CommandArgs
 		bookmarks         *Bookmarks
@@ -60,10 +78,10 @@ func TestExecuteCommandView(t *testing.T) {
 		tt.commandArgs.UserId = UserID
 		siteURL := "https://myhost.com"
 		api.On("GetPost", PostIDDoesNotExist).Return(nil, &model.AppError{Message: "An Error Occurred"})
-		api.On("GetPost", b1ID).Return(&model.Post{Message: "this is the post.Message"}, nil)
-		api.On("GetPost", b2ID).Return(&model.Post{Message: "this is the post.Message"}, nil)
-		api.On("GetPost", b3ID).Return(&model.Post{Message: "this is the post.Message"}, nil)
-		api.On("GetPost", b4ID).Return(&model.Post{Message: "this is the post.message"}, nil)
+		api.On("GetPost", b1ID).Return(p1IDmodel, nil)
+		api.On("GetPost", b2ID).Return(p2IDmodel, nil)
+		api.On("GetPost", b3ID).Return(p3IDmodel, nil)
+		api.On("GetPost", b4ID).Return(p4IDmodel, nil)
 		api.On("addBookmark", UserID, tt.bookmarks).Return(mock.Anything)
 		api.On("GetTeam", mock.Anything).Return(&model.Team{Id: teamID1}, nil)
 		api.On("GetConfig", mock.Anything).Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: &siteURL}})


### PR DESCRIPTION
This PR will automatically sort the bookmarks by post.CreateAt date when using `/bookmarks view`

Will create follow up tickets to make more idiomatic code, but works for now.

https://yourbasic.org/golang/how-to-sort-in-go/

Needed tickets:
* make better sorting functions, so call `sort.Sort(ByPostCreateAt(bmarks))`
* add test that checks sorting order

fixes #12 