### PR TITLE
correctly handle label remove command

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -25,6 +25,7 @@ const (
 **/bookmarks label**
 * |/bookmarks label <post_id> --labels <labels>| - add labels (comma-separated) to a bookmark
 * |/bookmarks label add <labels> | - create a new label
+* |/bookmarks label remove <labels> | - remove a label
 * |/bookmarks label view | - list all labels
 `
 	viewCommandText = `

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -73,7 +73,7 @@ func getExecuteCommandTestBookmarks() *Bookmarks {
 	}
 
 	labels := NewLabels()
-	labels.add(l1)
+	labels.add("UUID1", l1)
 
 	return bmarks
 }

--- a/server/kv_labels.go
+++ b/server/kv_labels.go
@@ -2,7 +2,7 @@ package main
 
 // Labels contains a map of labels with the label name as the key
 type Labels struct {
-	ByName map[string]*Label
+	ByID map[string]*Label
 }
 
 // Label defines the parameters of a label
@@ -14,24 +14,24 @@ type Label struct {
 // NewLabels returns an initialized Labels struct
 func NewLabels() *Labels {
 	labels := new(Labels)
-	labels.ByName = make(map[string]*Label)
+	labels.ByID = make(map[string]*Label)
 	return labels
 }
 
-func (l *Labels) add(label *Label) {
-	l.ByName[label.Name] = label
+func (l *Labels) add(UUID string, label *Label) {
+	l.ByID[UUID] = label
 }
 
 func (l *Labels) get(ID string) *Label {
-	return l.ByName[ID]
+	return l.ByID[ID]
 }
 
 func (l *Labels) delete(ID string) {
-	delete(l.ByName, ID)
+	delete(l.ByID, ID)
 }
 
 func (l *Labels) exists(ID string) (*Label, bool) {
-	if label, ok := l.ByName[ID]; ok {
+	if label, ok := l.ByID[ID]; ok {
 		return label, true
 	}
 	return nil, false

--- a/server/labels.go
+++ b/server/labels.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"encoding/base32"
 	"encoding/json"
 	"fmt"
 
+	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -12,13 +15,13 @@ const StoreLabelsKey = "labels"
 
 // storeLabels stores all the users labels
 func (p *Plugin) storeLabels(userID string, labels *Labels) error {
-	jsonBookmarks, jsonErr := json.Marshal(labels)
+	bb, jsonErr := json.Marshal(labels)
 	if jsonErr != nil {
 		return jsonErr
 	}
 
-	key := getBookmarksKey(userID)
-	appErr := p.MattermostPlugin.API.KVSet(key, jsonBookmarks)
+	key := getLabelsKey(userID)
+	appErr := p.MattermostPlugin.API.KVSet(key, bb)
 	if appErr != nil {
 		return errors.New(appErr.Error())
 	}
@@ -29,7 +32,7 @@ func (p *Plugin) storeLabels(userID string, labels *Labels) error {
 // getLabels returns a users Labels available for all their bookmarks.
 func (p *Plugin) getLabels(userID string) (*Labels, error) {
 
-	// if a user does not have bookmarks, bb will be nil
+	// if a user does not have labels, bb will be nil
 	bb, appErr := p.API.KVGet(getLabelsKey(userID))
 	if appErr != nil {
 		return nil, appErr
@@ -49,31 +52,100 @@ func (p *Plugin) getLabels(userID string) (*Labels, error) {
 }
 
 // addLabels stores labels available for bookmarks
-func (p *Plugin) addLabels(userID string, labelNames []string) (*Labels, error) {
+func (p *Plugin) getLabelByName(userID string, labelName string) (*Label, error) {
 
-	// get all bookmarks for user
+	// get all labels for user
 	labels, err := p.getLabels(userID)
 	if err != nil {
 		return nil, errors.New(err.Error())
 	}
 
-	// no marks, initialize the store first
 	if labels == nil {
-		labels = NewLabels()
+		return nil, nil
 	}
 
-	for _, name := range labelNames {
-		label := new(Label)
-		label.Name = name
-		labels.add(label)
+	for _, l := range labels.ByID {
+		if l.Name == labelName {
+			return l, nil
+		}
 	}
+
+	return nil, nil
+}
+
+// addLabels stores labels available for bookmarks
+func (p *Plugin) addLabel(userID string, labelName string) (*Label, error) {
+
+	// check if name already exists
+	label, err := p.getLabelByName(userID, labelName)
+
+	// User already has label with this labelName
+	if label != nil {
+		return nil, errors.New(fmt.Sprintf("Label with name `%s` already exists", label.Name))
+	}
+
+	// get all labels for user
+	labels, err := p.getLabels(userID)
+	if err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	// no labels, initialize the store and save
+	if labels == nil {
+		labels = NewLabels() // save first label
+	}
+
+	labelID := NewID()
+	label = &Label{
+		Name: labelName,
+	}
+	labels.add(labelID, label)
 
 	if err = p.storeLabels(userID, labels); err != nil {
 		return nil, errors.New(err.Error())
 	}
-	return labels, nil
+
+	return label, nil
+}
+
+// deleteLabel deletes a label from the store
+func (p *Plugin) deleteLabel(userID, labelName string) (*Label, error) {
+
+	labels, err := p.getLabels(userID)
+	if err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	if labels == nil {
+		return nil, errors.New(fmt.Sprintf("User doesn't have any labels"))
+	}
+
+	// check if exists
+	label, err := p.getLabelByName(userID, labelName)
+	if label == nil {
+		return nil, errors.New(fmt.Sprintf("Label with name `%s` doesn't exist", labelName))
+	}
+
+	labels.delete(labelName)
+	p.storeLabels(userID, labels)
+
+	return label, nil
 }
 
 func getLabelsKey(userID string) string {
 	return fmt.Sprintf("%s_%s", StoreLabelsKey, userID)
+}
+
+var encoding = base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769")
+
+// NewID is a globally unique identifier.  It is a [A-Z0-9] string 26
+// characters long.  It is a UUID version 4 Guid that is zbased32 encoded
+// with the padding stripped off.
+func NewID() string {
+	var b bytes.Buffer
+	encoder := base32.NewEncoder(encoding, &b)
+	encoder.Write(uuid.NewRandom())
+	encoder.Close()
+	b.Truncate(26) // removes the '==' padding
+	return b.String()
 }


### PR DESCRIPTION
correctly handle label remove command
store each label map key as a UUID instead of the Label.Name
  - This is done because the key should not track the label.name because
    a user might change the label name.

Fixes: 
#25 
#14 