### PR TITLE
Fix response when user has not labels

### DIFF
--- a/server/command_label.go
+++ b/server/command_label.go
@@ -97,15 +97,21 @@ func (p *Plugin) executeCommandLabelRemove(args *model.CommandArgs) *model.Comma
 		return p.responsef(args, "Please specify a label name %v", getHelp(labelCommandText))
 	}
 
-	labelName := subCommand[3]
-
 	l := NewLabels(p.API)
 	labels, err := l.getLabels(args.UserId)
+	if err != nil {
+		return p.responsef(args, err.Error())
+	}
+	if labels == nil || len(labels.ByID) == 0 {
+		return p.responsef(args, "You do not have any saved labels")
+	}
+
+	labelName := subCommand[3]
+
 	labelID, err := labels.getIDFromName(args.UserId, labelName)
 	if err != nil {
 		return p.responsef(args, err.Error())
 	}
-
 	b := NewBookmarks(p.API)
 	bmarks, err := b.getBookmarks(args.UserId)
 	if err != nil {
@@ -164,7 +170,7 @@ func (p *Plugin) executeCommandLabelView(args *model.CommandArgs) *model.Command
 	if err != nil {
 		return p.responsef(args, "Unable to retrieve bookmark for user %s", args.UserId)
 	}
-	if labels == nil {
+	if labels == nil || len(labels.ByID) == 0 {
 		return p.responsef(args, "You do not have any saved labels")
 	}
 

--- a/server/command_label_test.go
+++ b/server/command_label_test.go
@@ -73,7 +73,7 @@ func TestExecuteCommandLabel(t *testing.T) {
 			expectedContains:  []string{"Added Label: NewLabelName"},
 		},
 
-		// REMOVE
+		// REMOVE - user does not have any saved labels
 		"REMOVE User does not provide label name": {
 			commandArgs:       &model.CommandArgs{Command: "/bookmarks label remove"},
 			labels:            nil,
@@ -83,10 +83,12 @@ func TestExecuteCommandLabel(t *testing.T) {
 		"REMOVE User tries to remove a label but has none": {
 			commandArgs:       &model.CommandArgs{Command: "/bookmarks label remove JunkLabel"},
 			bookmarks:         nil,
-			labels:            getExecuteCommandTestLabels(),
-			expectedMsgPrefix: "",
-			expectedContains:  []string{"Label: `JunkLabel` does not exist"},
+			labels:            nil,
+			expectedMsgPrefix: "You do not have any saved labels",
+			expectedContains:  nil,
 		},
+
+		// REMOVE - user has saved labels
 		"REMOVE User tries to remove a label that does not exist": {
 			commandArgs:       &model.CommandArgs{Command: "/bookmarks label remove labeldoesnotexist"},
 			labels:            getExecuteCommandTestLabels(),

--- a/server/command_view.go
+++ b/server/command_view.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -25,8 +24,12 @@ func (p *Plugin) executeCommandView(args *model.CommandArgs) *model.CommandRespo
 	if err != nil {
 		return p.responsef(args, "Unable to retrieve bookmarks for user %s", args.UserId)
 	}
-	if bmarks == nil {
-		return p.responsef(args, fmt.Sprintf("You do not have any saved bookmarks"))
+
+	// bookmarks is nil if user has never added a bookmark.
+	// bookmarks.ByID will be empty if user created a bookmark and then deleted
+	// it and now has 0 bookmarks
+	if bmarks == nil || len(bmarks.ByID) == 0 {
+		return p.responsef(args, "You do not have any saved bookmarks")
 	}
 
 	// user requests to view an indiviual bookmark
@@ -43,13 +46,6 @@ func (p *Plugin) executeCommandView(args *model.CommandArgs) *model.CommandRespo
 			return p.responsef(args, "Unable to retrieve bookmark for user %s", args.UserId)
 		}
 		return p.responsef(args, text)
-	}
-
-	// bookmarks is nil if user has never added a bookmark.
-	// bookmarks.ByID will be empty if user created a bookmark and then deleted
-	// it and now has 0 bookmarks
-	if bmarks == nil || len(bmarks.ByID) == 0 {
-		return p.responsef(args, "You do not have any saved bookmarks")
 	}
 
 	text := "#### Bookmarks List\n"

--- a/server/command_view_test.go
+++ b/server/command_view_test.go
@@ -37,6 +37,7 @@ func TestExecuteCommandView(t *testing.T) {
 		expectedMsgPrefix string
 		expectedContains  []string
 	}{
+		// USER HAS NO BOOKMARKS
 		"User has no bookmarks": {
 			commandArgs:       &model.CommandArgs{Command: "/bookmarks view"},
 			bookmarks:         nil,
@@ -49,6 +50,8 @@ func TestExecuteCommandView(t *testing.T) {
 			expectedMsgPrefix: strings.TrimSpace("You do not have any saved bookmarks"),
 			expectedContains:  nil,
 		},
+
+		// VIEW INDIVIDUAL BOOKMARK
 		"User requests to view bookmark by ID that has a title defined": {
 			commandArgs:       &model.CommandArgs{Command: "/bookmarks view ID2"},
 			bookmarks:         getExecuteCommandTestBookmarks(),
@@ -61,6 +64,8 @@ func TestExecuteCommandView(t *testing.T) {
 				"this is the post.Message",
 			},
 		},
+
+		// VIEW ALL BOOKMARKS
 		"User has 3 bookmarks  All with titles provided": {
 			commandArgs:       &model.CommandArgs{Command: "/bookmarks view"},
 			bookmarks:         getExecuteCommandTestBookmarks(),


### PR DESCRIPTION
when viewing and removing labels, check to see if labels exist as early
as possible in the function

fixes #49 