### PR TITLE
refactor kv store and add error handling messages

### DIFF
--- a/server/bookmarks_test.go
+++ b/server/bookmarks_test.go
@@ -18,6 +18,7 @@ func makePlugin(api *plugintest.API) *Plugin {
 
 func TestStoreBookmarks(t *testing.T) {
 	api := makeAPIMock()
+	api.On("KVSet", mock.Anything, mock.Anything).Return(nil)
 	p := makePlugin(api)
 
 	// initialize test Bookmarks
@@ -29,8 +30,10 @@ func TestStoreBookmarks(t *testing.T) {
 
 	// Add Bookmarks
 	bmarks := NewBookmarksWithUser(p.API, u1)
-	bmarks.add(b1)
-	bmarks.add(b2)
+	err := bmarks.add(b1)
+	assert.Nil(t, err)
+	err = bmarks.add(b2)
+	assert.Nil(t, err)
 
 	// Markshal the bmarks and mock api call
 	jsonBookmarks, err := json.Marshal(bmarks)
@@ -59,11 +62,14 @@ func TestAddBookmark(t *testing.T) {
 	u1 := "userID1"
 	bmarksU1 := NewBookmarksWithUser(p.API, u1)
 
+	api.On("KVSet", mock.Anything, mock.Anything).Return(nil)
 	// User 2 has 2 existing bookmarks
 	u2 := "userID2"
 	bmarksU2 := NewBookmarksWithUser(p.API, u2)
-	bmarksU2.add(b1)
-	bmarksU2.add(b2)
+	err := bmarksU2.add(b1)
+	assert.Nil(t, err)
+	err = bmarksU2.add(b2)
+	assert.Nil(t, err)
 
 	tests := []struct {
 		name    string
@@ -107,6 +113,7 @@ func TestAddBookmark(t *testing.T) {
 
 func TestDeleteBookmark(t *testing.T) {
 	api := makeAPIMock()
+	api.On("KVSet", mock.Anything, mock.Anything).Return(nil)
 	p := makePlugin(api)
 
 	// create some test bookmarks
@@ -124,8 +131,10 @@ func TestDeleteBookmark(t *testing.T) {
 	// User 2 has 2 existing bookmarks
 	u2 := "userID2"
 	bmarksU2 := NewBookmarksWithUser(p.API, u2)
-	bmarksU2.add(b1)
-	bmarksU2.add(b2)
+	err := bmarksU2.add(b1)
+	assert.Nil(t, err)
+	err = bmarksU2.add(b2)
+	assert.Nil(t, err)
 
 	tests := []struct {
 		name       string

--- a/server/command_label_test.go
+++ b/server/command_label_test.go
@@ -24,10 +24,11 @@ func getExecuteCommandTestLabels() *Labels {
 	}
 
 	api := makeAPIMock()
+	api.On("KVSet", mock.Anything, mock.Anything).Return(nil)
 	labels := NewLabelsWithUser(api, UserID)
-	labels.add("UUID1", l1)
-	labels.add("UUID2", l2)
-	labels.add("UUID3", l3)
+	_ = labels.add("UUID1", l1)
+	_ = labels.add("UUID2", l2)
+	_ = labels.add("UUID3", l3)
 
 	return labels
 }

--- a/server/command_test.go
+++ b/server/command_test.go
@@ -31,6 +31,7 @@ const (
 
 func getExecuteCommandTestBookmarks() *Bookmarks {
 	api := makeAPIMock()
+	api.On("KVSet", mock.Anything, mock.Anything).Return(nil)
 	p := makePlugin(api)
 	bmarks := NewBookmarksWithUser(p.API, UserID)
 
@@ -58,17 +59,17 @@ func getExecuteCommandTestBookmarks() *Bookmarks {
 		ModifiedAt: model.GetMillis(),
 	}
 
-	bmarks.add(b1)
-	bmarks.add(b2)
-	bmarks.add(b3)
-	bmarks.add(b4)
+	_ = bmarks.add(b1)
+	_ = bmarks.add(b2)
+	_ = bmarks.add(b3)
+	_ = bmarks.add(b4)
 
 	l1 := &Label{
 		Name: "label1",
 	}
 
 	labels := NewLabels(api)
-	labels.add("UUID1", l1)
+	_ = labels.add("UUID1", l1)
 
 	return bmarks
 }

--- a/server/kv_bookmarks_test.go
+++ b/server/kv_bookmarks_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func getTestBookmarks() *Bookmarks {
 	api := makeAPIMock()
+	api.On("KVSet", mock.Anything, mock.Anything).Return(nil)
 	p := makePlugin(api)
 	bmarks := NewBookmarksWithUser(p.API, UserID)
 
@@ -31,9 +33,9 @@ func getTestBookmarks() *Bookmarks {
 		ModifiedAt: model.GetMillis(),
 	}
 
-	bmarks.add(b1)
-	bmarks.add(b2)
-	bmarks.add(b3)
+	_ = bmarks.add(b1)
+	_ = bmarks.add(b2)
+	_ = bmarks.add(b3)
 
 	return bmarks
 }
@@ -49,7 +51,8 @@ func TestBookmarks_add(t *testing.T) {
 	b4 := &Bookmark{PostID: "ID4", Title: "Title4"}
 	bmarks := getTestBookmarks()
 	assert.Equal(t, 3, len(bmarks.ByID))
-	bmarks.add(b4)
+	err := bmarks.add(b4)
+	assert.Nil(t, err)
 	assert.Equal(t, 4, len(bmarks.ByID))
 }
 

--- a/server/labels.go
+++ b/server/labels.go
@@ -13,22 +13,6 @@ import (
 // StoreLabelsKey is the key used to store labels in the plugin KV store
 const StoreLabelsKey = "labels"
 
-// storeLabels stores all the users labels
-func (l *Labels) storeLabels() error {
-	bb, jsonErr := json.Marshal(l)
-	if jsonErr != nil {
-		return jsonErr
-	}
-
-	key := getLabelsKey(l.userID)
-	appErr := l.api.KVSet(key, bb)
-	if appErr != nil {
-		return errors.New(appErr.Error())
-	}
-
-	return nil
-}
-
 // getNameFromID returns the Name of a Label
 func (l *Labels) getNameFromID(id string) (string, error) {
 	label, err := l.get(id)
@@ -99,9 +83,7 @@ func (l *Labels) addLabel(labelName string) (*Label, error) {
 		Name: labelName,
 		ID:   labelID,
 	}
-	l.add(labelID, label)
-
-	if err := l.storeLabels(); err != nil {
+	if err := l.add(labelID, label); err != nil {
 		return nil, err
 	}
 
@@ -110,8 +92,7 @@ func (l *Labels) addLabel(labelName string) (*Label, error) {
 
 // deleteByID deletes a label from the store
 func (l *Labels) deleteByID(labelID string) error {
-	l.delete(labelID)
-	if err := l.storeLabels(); err != nil {
+	if err := l.delete(labelID); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Resolves #82 

  - add/delete methods for labels and bookmark now does the KVSet and store
    functions so user doesn't need to remember to store after an add or
    delete method
Added err handling.
  - add / delete methods now handle the error with a message so caller
    doens't need to wrap with more info
