### PR TITLE
[GH-113] close modal by clicking x in header or escape key

### DIFF
--- a/webapp/src/components/modals/add_bookmark/add_bookmark.tsx
+++ b/webapp/src/components/modals/add_bookmark/add_bookmark.tsx
@@ -12,7 +12,6 @@ export type Props = {
 }
 
 export default class AddBookmarkModal extends PureComponent<Props, State> {
-
     handleClose = (e) => {
         if (e && e.preventDefault) {
             e.preventDefault();

--- a/webapp/src/components/modals/add_bookmark/add_bookmark.tsx
+++ b/webapp/src/components/modals/add_bookmark/add_bookmark.tsx
@@ -8,9 +8,18 @@ import AddBookmarkForm from './add_bookmark_form';
 
 export type Props = {
     visible: boolean;
+    close: () => void;
 }
 
 export default class AddBookmarkModal extends PureComponent<Props, State> {
+
+    handleClose = (e) => {
+        if (e && e.preventDefault) {
+            e.preventDefault();
+        }
+        this.props.close();
+    };
+
     render() {
         let content;
         if (this.props.visible) {
@@ -27,6 +36,8 @@ export default class AddBookmarkModal extends PureComponent<Props, State> {
                 dialogClassName='modal--scroll'
                 style={style.modal}
                 show={this.props.visible}
+                onHide={this.handleClose}
+                onExited={this.handleClose}
                 bsSize='large'
                 backdrop='static'
             >


### PR DESCRIPTION
fixes: #113 
allow closing the modal by:
  - clicking x in upper RHS
  - hitting escape button

Debated on clicking outside of the modal, but GH plugin doesn't use this.  Perhaps our internal plugins should have a convention derived from UX team?