### PR TITLE
Fix icon link

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.13
 
 require (
 	github.com/go-ldap/ldap v3.0.3+incompatible // indirect
+	github.com/go-redis/redis v6.15.9+incompatible // indirect
+	github.com/golang/mock v1.2.0
 	github.com/gorilla/mux v1.7.4
 	github.com/mattermost/mattermost-server v5.11.1+incompatible
 	github.com/mattermost/mattermost-server/v5 v5.24.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Masterminds/glide v0.13.2/go.mod h1:STyF5vcenH/rUqTEv+/hBXlSTo7KYwg2oc2f4tzPWic=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/squirrel v1.2.0 h1:K1NhbTO21BWG47IVR0OnIZuE0LZcXAYqywrC3Ko53KI=
 github.com/Masterminds/squirrel v1.2.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/Masterminds/vcs v1.13.0/go.mod h1:N09YCmOQr6RLxC6UNHzuVwAdodYbbnycGHSmwVJjcKA=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
@@ -141,7 +142,10 @@ github.com/go-ldap/ldap v3.0.3+incompatible h1:HTeSZO8hWMS1Rgb2Ziku6b8a7qRIZZMHj
 github.com/go-ldap/ldap v3.0.3+incompatible/go.mod h1:qfd9rJvER9Q0/D/Sqn1DfHRoBp40uXYvFoEVrNEPqRc=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-redis/redis v6.15.9+incompatible h1:K0pv1D7EQUjfyoMql+r/jZqCLizCGKFlFgcHWWmHQjg=
+github.com/go-redis/redis v6.15.9+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -155,6 +159,7 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfU
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
@@ -285,6 +290,7 @@ github.com/lann/builder v0.0.0-20180802200727-47ae307949d0/go.mod h1:dXGbAdH5GtB
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 h1:P6pPBnrTSX3DEVR4fDembhRWSsG5rVo6hYhAB/ADZrk=
 github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6FmdpVm2joNMFikkuWg0EoCKLGUMNw=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.4.0 h1:TmtCFbH+Aw0AixwyttznSMQDgbR5Yed/Gg6S8Funrhc=
 github.com/lib/pq v1.4.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -299,7 +305,6 @@ github.com/mattermost/gorp v2.0.1-0.20190301154413-3b31e9a39d05+incompatible/go.
 github.com/mattermost/gosaml2 v0.3.2/go.mod h1:Z429EIOiEi9kbq6yHoApfzlcXpa6dzRDc6pO+Vy2Ksk=
 github.com/mattermost/ldap v0.0.0-20191128190019-9f62ba4b8d4d h1:2DV7VIlEv6J5R5o6tUcb3ZMKJYeeZuWZL7Rv1m23TgQ=
 github.com/mattermost/ldap v0.0.0-20191128190019-9f62ba4b8d4d/go.mod h1:HLbgMEI5K131jpxGazJ97AxfPDt31osq36YS1oxFQPQ=
-github.com/mattermost/mattermost-server v1.4.0 h1:bAN0zYgjyhXPy67VTiHLg+bu8mDJ2bhx109BKk2Ddos=
 github.com/mattermost/mattermost-server v5.11.1+incompatible h1:LPzKY0+2Tic/ik67qIg6VrydRCgxNXZQXOeaiJ2rMBY=
 github.com/mattermost/mattermost-server v5.11.1+incompatible/go.mod h1:5L6MjAec+XXQwMIt791Ganu45GKsSiM+I0tLR9wUj8Y=
 github.com/mattermost/mattermost-server/v5 v5.24.0 h1:7aW85q2nPOFgjzOCO1k4m3azdvIClZT3UShY1fYYSdc=

--- a/server/bookmarks/bookmarks.go
+++ b/server/bookmarks/bookmarks.go
@@ -269,7 +269,7 @@ func (b *Bookmarks) GetBmarkTextOneLine(bmark *Bookmark, labelNames []string) (s
 		codeBlockedNames = " " + utils.TitleFromPostLabel + codeBlockedNames
 	}
 
-	text := fmt.Sprintf("%s%s %s\n", utils.GetIconLink(bmark.PostID), codeBlockedNames, title)
+	text := fmt.Sprintf("%s%s %s\n", getIconLink(b.api, bmark.PostID), codeBlockedNames, title)
 
 	return text, nil
 }
@@ -358,7 +358,7 @@ func (b *Bookmarks) GetBmarkTextDetailed(bmark *Bookmark, labelNames []string, a
 		return "", appErr
 	}
 
-	iconLink := utils.GetIconLink(bmark.PostID)
+	iconLink := getIconLink(b.api, bmark.PostID)
 
 	text := fmt.Sprintf("%s\n#### Bookmark Title %s\n", codeBlockedNames, iconLink)
 	text += fmt.Sprintf("**%s**\n", title)
@@ -366,4 +366,25 @@ func (b *Bookmarks) GetBmarkTextDetailed(bmark *Bookmark, labelNames []string, a
 	text += post.Message
 
 	return text, nil
+}
+
+// getPermaLink returns a link to a postID
+func getPermaLink(siteURL, postID string) string {
+	return fmt.Sprintf("%v/_redirect/pl/%v", siteURL, postID)
+}
+
+// GetSiteURL returns the SiteURL from the config settings
+func GetSiteURL(api pluginapi.API) string {
+	ptr := api.GetConfig().ServiceSettings.SiteURL
+	// if ptr == nil {
+	// 	return ""
+	// }
+	return *ptr
+}
+
+// getIconLink returns a markdown link to a postID including a :link: icon
+func getIconLink(api pluginapi.API, postID string) string {
+	url := GetSiteURL(api)
+	iconLink := fmt.Sprintf("[:link:](%s)", getPermaLink(url, postID))
+	return iconLink
 }

--- a/server/bookmarks/bookmarks.go
+++ b/server/bookmarks/bookmarks.go
@@ -367,24 +367,3 @@ func (b *Bookmarks) GetBmarkTextDetailed(bmark *Bookmark, labelNames []string, a
 
 	return text, nil
 }
-
-// getPermaLink returns a link to a postID
-func getPermaLink(siteURL, postID string) string {
-	return fmt.Sprintf("%v/_redirect/pl/%v", siteURL, postID)
-}
-
-// GetSiteURL returns the SiteURL from the config settings
-func GetSiteURL(api pluginapi.API) string {
-	ptr := api.GetConfig().ServiceSettings.SiteURL
-	// if ptr == nil {
-	// 	return ""
-	// }
-	return *ptr
-}
-
-// getIconLink returns a markdown link to a postID including a :link: icon
-func getIconLink(api pluginapi.API, postID string) string {
-	url := GetSiteURL(api)
-	iconLink := fmt.Sprintf("[:link:](%s)", getPermaLink(url, postID))
-	return iconLink
-}

--- a/server/bookmarks/mock_bookmarks/mock_bookmarks.go
+++ b/server/bookmarks/mock_bookmarks/mock_bookmarks.go
@@ -5,10 +5,9 @@
 package mock_bookmarks
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	bookmarks "github.com/jfrerich/mattermost-plugin-bookmarks/server/bookmarks"
+	reflect "reflect"
 )
 
 // MockIBookmarks is a mock of IBookmarks interface
@@ -32,20 +31,6 @@ func NewMockIBookmarks(ctrl *gomock.Controller) *MockIBookmarks {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockIBookmarks) EXPECT() *MockIBookmarksMockRecorder {
 	return m.recorder
-}
-
-// Add mocks base method
-func (m *MockIBookmarks) Add(arg0 *bookmarks.Bookmark) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Add", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Add indicates an expected call of Add
-func (mr *MockIBookmarksMockRecorder) Add(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockIBookmarks)(nil).Add), arg0)
 }
 
 // AddBookmark mocks base method

--- a/server/bookmarks/utils.go
+++ b/server/bookmarks/utils.go
@@ -1,0 +1,24 @@
+package bookmarks
+
+import (
+	"fmt"
+
+	"github.com/jfrerich/mattermost-plugin-bookmarks/server/pluginapi"
+)
+
+// getPermaLink returns a link to a postID
+func getPermaLink(siteURL, postID string) string {
+	return fmt.Sprintf("%v/_redirect/pl/%v", siteURL, postID)
+}
+
+// getSiteURL returns the SiteURL from the config settings
+func getSiteURL(api pluginapi.API) string {
+	return *api.GetConfig().ServiceSettings.SiteURL
+}
+
+// getIconLink returns a markdown link to a postID including a :link: icon
+func getIconLink(api pluginapi.API, postID string) string {
+	url := getSiteURL(api)
+	iconLink := fmt.Sprintf("[:link:](%s)", getPermaLink(url, postID))
+	return iconLink
+}

--- a/server/bookmarks/utils.go
+++ b/server/bookmarks/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jfrerich/mattermost-plugin-bookmarks/server/pluginapi"
+	"github.com/jfrerich/mattermost-plugin-bookmarks/server/utils"
 )
 
 // getPermaLink returns a link to a postID
@@ -11,14 +12,9 @@ func getPermaLink(siteURL, postID string) string {
 	return fmt.Sprintf("%v/_redirect/pl/%v", siteURL, postID)
 }
 
-// getSiteURL returns the SiteURL from the config settings
-func getSiteURL(api pluginapi.API) string {
-	return *api.GetConfig().ServiceSettings.SiteURL
-}
-
 // getIconLink returns a markdown link to a postID including a :link: icon
 func getIconLink(api pluginapi.API, postID string) string {
-	url := getSiteURL(api)
+	url := utils.GetSiteURL(api)
 	iconLink := fmt.Sprintf("[:link:](%s)", getPermaLink(url, postID))
 	return iconLink
 }

--- a/server/command/command_add_test.go
+++ b/server/command/command_add_test.go
@@ -152,6 +152,14 @@ func TestExecuteCommandAdd(t *testing.T) {
 		defer ctrl.Finish()
 		mockPluginAPI := mock_pluginapi.NewMockAPI(ctrl)
 
+		config := &model.Config{
+			ServiceSettings: model.ServiceSettings{
+				SiteURL: model.NewString("https://myhost.com"),
+			},
+		}
+		mockPluginAPI.EXPECT().GetConfig().Return(config).AnyTimes()
+
+		mockPluginAPI.EXPECT().GetConfig().Return(config).AnyTimes()
 		mockPluginAPI.EXPECT().GetPost(PostIDDoesNotExist).Return(nil, &model.AppError{Message: "An Error Occurred"}).AnyTimes()
 		mockPluginAPI.EXPECT().GetPost(p1ID).Return(p1IDmodel, nil).AnyTimes()
 		mockPluginAPI.EXPECT().GetPost(p2ID).Return(p2IDmodel, nil).AnyTimes()

--- a/server/command/command_remove_test.go
+++ b/server/command/command_remove_test.go
@@ -68,6 +68,13 @@ func TestExecuteCommandRemove(t *testing.T) {
 		jsonLabels, err := json.Marshal(labels)
 		assert.Nil(t, err)
 
+		config := &model.Config{
+			ServiceSettings: model.ServiceSettings{
+				SiteURL: model.NewString("https://myhost.com"),
+			},
+		}
+		mockPluginAPI.EXPECT().GetConfig().Return(config).AnyTimes()
+
 		mockPluginAPI.EXPECT().KVSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 		mockPluginAPI.EXPECT().KVGet(bookmarks.GetLabelsKey(UserID)).Return(jsonLabels, nil).AnyTimes()

--- a/server/command/command_view_test.go
+++ b/server/command/command_view_test.go
@@ -118,6 +118,12 @@ func TestExecuteCommandView(t *testing.T) {
 		defer ctrl.Finish()
 		mockPluginAPI := mock_pluginapi.NewMockAPI(ctrl)
 
+		config := &model.Config{
+			ServiceSettings: model.ServiceSettings{
+				SiteURL: model.NewString("https://myhost.com"),
+			},
+		}
+		mockPluginAPI.EXPECT().GetConfig().Return(config).AnyTimes()
 		mockPluginAPI.EXPECT().GetPost(PostIDDoesNotExist).Return(nil, &model.AppError{Message: "An Error Occurred"}).AnyTimes()
 		mockPluginAPI.EXPECT().GetPost(p1ID).Return(p1IDmodel, nil).AnyTimes()
 		mockPluginAPI.EXPECT().GetPost(p2ID).Return(p2IDmodel, nil).AnyTimes()

--- a/server/http_test.go
+++ b/server/http_test.go
@@ -168,15 +168,14 @@ func TestHandleAddBookmark(t *testing.T) {
 			jsonBmarks, err := json.Marshal(tt.bookmarks)
 			assert.Nil(t, err)
 
-			// siteURL := "https://myhost.com"
-			// api.On("KVSet", mock.Anything, mock.Anything).Return(nil)
-			// mockPluginAPI.EXPECT().KVSet(mock.Anything, mock.Anything)
+			siteURL := "https://myhost.com"
 
 			api.On("KVSet", mock.Anything, mock.Anything).Return(nil)
 			api.On("KVGet", bookmarks.GetBookmarksKey(UserID)).Return(jsonBmarks, nil)
 			api.On("KVGet", bookmarks.GetLabelsKey(UserID)).Return(nil, nil)
 			api.On("GetPost", tt.bookmark.PostID).Return(&model.Post{Message: "this is the post.Message"}, nil)
-			// api.On("GetConfig", mock.Anything).Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: &siteURL}})
+
+			api.On("GetConfig", mock.Anything).Return(&model.Config{ServiceSettings: model.ServiceSettings{SiteURL: &siteURL}})
 			// mockPluginAPI.EXPECT().KVSet(bookmarks.GetBookmarksKey(UserID), gomock.Any)
 			// mockPluginAPI.EXPECT().KVSet("bookmarks_UserID", jsonBmark).Return(nil)
 			// mockPluginAPI.EXPECT().KVSet(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()

--- a/server/pluginapi/api.go
+++ b/server/pluginapi/api.go
@@ -11,6 +11,7 @@ type api struct {
 
 type API interface {
 	GetPost(postID string) (*model.Post, error)
+	GetConfig() *model.Config
 	KVSet(key string, value []byte) error
 	KVGet(key string) ([]byte, error)
 }
@@ -43,4 +44,8 @@ func (a *api) KVGet(key string) ([]byte, error) {
 		return nil, appErr
 	}
 	return value, nil
+}
+
+func (a *api) GetConfig() *model.Config {
+	return a.papi.GetConfig()
 }

--- a/server/pluginapi/mock_pluginapi/mock_pluginapi.go
+++ b/server/pluginapi/mock_pluginapi/mock_pluginapi.go
@@ -33,6 +33,20 @@ func (m *MockAPI) EXPECT() *MockAPIMockRecorder {
 	return m.recorder
 }
 
+// GetConfig mocks base method
+func (m *MockAPI) GetConfig() *model.Config {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfig")
+	ret0, _ := ret[0].(*model.Config)
+	return ret0
+}
+
+// GetConfig indicates an expected call of GetConfig
+func (mr *MockAPIMockRecorder) GetConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockAPI)(nil).GetConfig))
+}
+
 // GetPost mocks base method
 func (m *MockAPI) GetPost(arg0 string) (*model.Post, error) {
 	m.ctrl.T.Helper()

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"regexp"
 
+	"github.com/jfrerich/mattermost-plugin-bookmarks/server/pluginapi"
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
 
@@ -28,4 +29,9 @@ func GetLegendText() string {
 	text += "`label` - **_Italicized & Bolded text signifies the bookmark has a saved title_**\n\n"
 	text += "***\n"
 	return text
+}
+
+// getSiteURL returns the SiteURL from the config settings
+func GetSiteURL(api pluginapi.API) string {
+	return *api.GetConfig().ServiceSettings.SiteURL
 }

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -1,17 +1,10 @@
 package utils
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/mattermost/mattermost-server/v5/plugin"
 )
-
-// getPermaLink returns a link to a postID
-func getPermaLink(postID string) string {
-	url := "https://myhost.com"
-	return fmt.Sprintf("%v/_redirect/pl/%v", url, postID)
-}
 
 // GetPostIDFromLink extracts a PostID from a link
 func GetPostIDFromLink(s string) string {
@@ -20,12 +13,6 @@ func GetPostIDFromLink(s string) string {
 		return r.FindStringSubmatch(s)[1]
 	}
 	return s
-}
-
-// GetIconLink returns a markdown link to a postID including a :link: icon
-func GetIconLink(postID string) string {
-	iconLink := fmt.Sprintf("[:link:](%s)", getPermaLink(postID))
-	return iconLink
 }
 
 type API struct {


### PR DESCRIPTION
Fixes: #131 

building the link required accessing the config and the siteURL.  instead of adding the API to the utils package, I decided to pull the functions in the bookmarks package